### PR TITLE
Use regular stdout/stderr logging instead of standalone file

### DIFF
--- a/gen_intake_gfdl.py
+++ b/gen_intake_gfdl.py
@@ -5,8 +5,6 @@ import os
 from intakebuilder import gfdlcrawler, CSVwriter, builderconfig
 import logging
 logger = logging.getLogger('local')
-hdlr = logging.FileHandler(builderconfig.logfile)
-logger.addHandler(hdlr)
 logger.setLevel(logging.INFO)
 
 @click.command()


### PR DESCRIPTION
Using a standalone file is more problematic as the filepath may not exist.

There are some errors we see when run through the Cylc workflow.

    PermissionError: [Errno 13] Permission denied: '/tmp/intakegfdl.log'

that this update fixes.