### PR TITLE
New changes to file path parsing & path expectations + CSV file clean up

### DIFF
--- a/TestInstructions
+++ b/TestInstructions
@@ -1,0 +1,12 @@
+How to test:
+
+The catalog builder wrapper accepts two arguments: an input path where data is stored and an output path to which the final CSV file will be generated.
+
+In order to overwrite any existing CSV file at the given output path, the  '--overwrite' flag can be used.
+In order to append any existing CSV file at the given output path, the  '--append' flag can be used.
+
+The following example generates a sample catalog called ‘output.csv’ to the home directory: 
+/gen_intake_gfdl.py /archive/am5/am5/am5f3b1r0/c96L65_am5f3b1r0_pdclim1850F/gfdl.ncrc5-deploy-prod-openmp/pp ~/output.csv
+
+NOTE: Currently only time series output files are included in output CSV.
+

--- a/gen_intake_gfdl.py
+++ b/gen_intake_gfdl.py
@@ -9,6 +9,7 @@ hdlr = logging.FileHandler(builderconfig.logfile)
 logger.addHandler(hdlr)
 logger.setLevel(logging.INFO)
 
+#Setting up argument parsing/flags
 @click.command()
 @click.argument("inputdir", required=True, nargs=1) 
 @click.argument("outputdir", required=True, nargs=1)

--- a/gen_intake_gfdl.py
+++ b/gen_intake_gfdl.py
@@ -44,7 +44,7 @@ def main(inputdir,outputdir,filter_realm,filter_freq,filter_chunk,overwrite,appe
     #########################################################
     dictInfo = {}
     project_dir = project_dir.rstrip("/")
-    logger.info("Calling gfdlcrawler.crawlLocal") 
+    logger.info("Calling gfdlcrawler.crawlLocal")
     list_files = gfdlcrawler.crawlLocal(project_dir, dictFilter, dictFilterIgnore,logger)
     headers = CSVwriter.getHeader()
     if (not os.path.exists(csvfile)):

--- a/intakebuilder/CSVwriter.py
+++ b/intakebuilder/CSVwriter.py
@@ -42,6 +42,7 @@ def file_appender(dictinputs, csvfile):
 
 def listdict_to_csv(dict_info,headerlist, csvfile, overwrite, append):
     try:
+        #Open the CSV file in write mode and add any data with atleast 3 values associated with it
         if overwrite:
             with open(csvfile, 'w') as csvfile:
                 writer = csv.DictWriter(csvfile, fieldnames=headerlist)
@@ -50,14 +51,16 @@ def listdict_to_csv(dict_info,headerlist, csvfile, overwrite, append):
                 for data in dict_info:
                     if len(data.keys()) > 2:
                         writer.writerow(data)
+        #Open the CSV file in append mode and add any data with atleast 3 values associated with it
         if append:
             with open(csvfile, 'a') as csvfile:
                 writer = csv.DictWriter(csvfile, fieldnames=headerlist)
                 print("writing..")
                 writer.writeheader()
                 for data in dict_info:
-                    writer.writerow(data)
-
+                    if len(data.keys()) > 2:
+                        writer.writerow(data)
+        #If neither overwrite nor append flags are found, check if a csv file already exists. If so, prompt user on what to do. If not, write to the file. 
         if not any((overwrite, append)):
             if os.path.isfile(csvfile):
                 user_input = ''
@@ -81,6 +84,7 @@ def listdict_to_csv(dict_info,headerlist, csvfile, overwrite, append):
                             for data in dict_info:
                                 writer.writerow(data)
                         break
+                    #If the user types anything besides y/n, keep asking
                     else:
                         print('Type y/n')
             else:

--- a/intakebuilder/CSVwriter.py
+++ b/intakebuilder/CSVwriter.py
@@ -48,7 +48,8 @@ def listdict_to_csv(dict_info,headerlist, csvfile, overwrite, append):
                 print("writing..")
                 writer.writeheader()
                 for data in dict_info:
-                    writer.writerow(data)       
+                    if len(data.keys()) > 2:
+                        writer.writerow(data)
         if append:
             with open(csvfile, 'a') as csvfile:
                 writer = csv.DictWriter(csvfile, fieldnames=headerlist)

--- a/intakebuilder/CSVwriter.py
+++ b/intakebuilder/CSVwriter.py
@@ -73,15 +73,21 @@ def listdict_to_csv(dict_info,headerlist, csvfile, overwrite, append):
                         break
                     
                     elif user_input.lower() == 'n':
-                        print("appending to existing file...")
                         with open(csvfile, 'a') as csvfile:
                             writer = csv.DictWriter(csvfile, fieldnames=headerlist)
-                            print("writing..")
+                            print("appending to existing file...")
                             writer.writeheader()
                             for data in dict_info:
                                 writer.writerow(data)
                         break
                     else:
                         print('Type y/n')
+            else:
+                with open(csvfile, 'w') as csvfile:
+                    writer = csv.DictWriter(csvfile, fieldnames=headerlist)
+                    print("writing..")
+                    writer.writeheader()
+                    for data in dict_info:
+                        writer.writerow(data)
     except IOError:
         print("I/O error")

--- a/intakebuilder/builderconfig.py
+++ b/intakebuilder/builderconfig.py
@@ -1,8 +1,3 @@
-#project_dir = "/Users/ar46/data_cmip6/CMIP6/"  # DRS COMPLIANT PROJECT DIR
-project_dir = "/archive/oar.gfdl.cmip6/ESM4/DECK/ESM4_1pctCO2_D1/gfdl.ncrc4-intel16-prod-openmp/pp/"
-
-#/archive/oar.gfdl.cmip6/ESM4/DECK/ESM4_1pctCO2_D1/gfdl.ncrc4-intel16-prod-openmp/pp/atmos/ts/monthly/5yr/atmos.014601-015012.evap.nc 
-
 #what kind of directory structure to expect? 
 
 output_path_template = ['source_id','activity_id','experiment_id','platform','custom_pp','modeling_realm','custom_cell_methods','frequency','chunk_freq']

--- a/intakebuilder/getinfo.py
+++ b/intakebuilder/getinfo.py
@@ -78,25 +78,6 @@ def getInfoFromFilename(filename,dictInfo,logger):
         logger.debug("Filename not compatible with this version of the builder:"+filename)
     return dictInfo
 
-def getInfoFromGFDLFilename(filename,dictInfo,logger):
-    # 5 AR: get the following from the netCDF filename e.g. atmos.200501-200912.t_ref.nc
-    #output_file_template = ['modeling_realm','temporal_subset','variable_id']
-
-    if(filename.endswith(".nc")):
-        ncfile = filename.split(".nc")
-        ncfilename = ncfile[0].split(".")
-
-    nlen = len(builderconfig.output_file_template) # ['modeling_realm','temporal_subset','variable_id']
-    #lets go backwards and match given input directory to the template, add things to dictInfo
-    #for i in range(1,nlen+1):
-    #    try:
-    #        dictInfo[builderconfig.output_file_template[nlen-i]] = ncfilename[-i]
-    #  except:
-    #      sys.exit("oops in getInfoFromGFDLFilename")
-    #else:
-    #    logger.debug("Filename not compatible with this version of the builder:"+filename)
-    return dictInfo
-
 def getInfoFromGFDLDRS(dirpath,projectdir,dictInfo):
     '''
     Returns info from project directory and the DRS path to the file
@@ -109,8 +90,7 @@ def getInfoFromGFDLDRS(dirpath,projectdir,dictInfo):
    #               "ensemble_member", "grid_label", "variable",
    #               "temporal subset", "version", "path"]
  
-#/archive/oar.gfdl.cmip6/ESM4/DECK/ESM4_historical_D1/gfdl.ncrc4-intel16-prod-openmp/pp/atmos/ts/monthly/5yr/DO_NOT_USE/atmos.201001-201412.alb_sfc.nc
-
+#Grab values based on their expected position in path 
     stemdir = dirpath.split("/")
     if stemdir[len(stemdir)-3] == "ts":
         dictInfo['experiment_id'] = stemdir[len(stemdir)-7]
@@ -125,13 +105,6 @@ def getInfoFromGFDLDRS(dirpath,projectdir,dictInfo):
         dictInfo['chunk_frequency'] = stemdir[len(stemdir)-1]
 
 
-    #nlen = len(builderconfig.output_path_template)
-    #lets go backwards and match given input directory to the template, add things to dictInfo 
-    #for i in range(1,nlen+1):
-    #  try:
-    #      dictInfo[builderconfig.output_path_template[nlen-i]] = stemdir[-i]
-    #  except:
-    #      sys.exit("oops in getInfoFromGFDLDRS")
     return dictInfo
 
 def getInfoFromDRS(dirpath,projectdir,dictInfo):

--- a/intakebuilder/getinfo.py
+++ b/intakebuilder/getinfo.py
@@ -111,14 +111,27 @@ def getInfoFromGFDLDRS(dirpath,projectdir,dictInfo):
  
 #/archive/oar.gfdl.cmip6/ESM4/DECK/ESM4_historical_D1/gfdl.ncrc4-intel16-prod-openmp/pp/atmos/ts/monthly/5yr/DO_NOT_USE/atmos.201001-201412.alb_sfc.nc
 
-    stemdir = dirpath.split("/") 
-    nlen = len(builderconfig.output_path_template)
+    stemdir = dirpath.split("/")
+    if stemdir[len(stemdir)-3] == "ts":
+        dictInfo['experiment_id'] = stemdir[len(stemdir)-7]
+        dictInfo['frequency'] = stemdir[len(stemdir)-2]
+        dictInfo['member_id'] = 'n/a'
+        dictInfo['modeling_realm'] = stemdir[len(stemdir)-4]
+
+        #Finds last (a) and second to last (b) periods and grabs value between them
+        a = dictInfo['path'].rfind('.')
+        b = dictInfo['path'].rfind('.',0,dictInfo['path'].rfind('.')-1)
+        dictInfo['variable_id'] = dictInfo['path'][b+1:a]
+        dictInfo['chunk_frequency'] = stemdir[len(stemdir)-1]
+
+
+    #nlen = len(builderconfig.output_path_template)
     #lets go backwards and match given input directory to the template, add things to dictInfo 
-    for i in range(1,nlen+1):
-      try:
-          dictInfo[builderconfig.output_path_template[nlen-i]] = stemdir[-i]
-      except:
-          sys.exit("oops in getInfoFromGFDLDRS")
+    #for i in range(1,nlen+1):
+    #  try:
+    #      dictInfo[builderconfig.output_path_template[nlen-i]] = stemdir[-i]
+    #  except:
+    #      sys.exit("oops in getInfoFromGFDLDRS")
     return dictInfo
 
 def getInfoFromDRS(dirpath,projectdir,dictInfo):

--- a/intakebuilder/getinfo.py
+++ b/intakebuilder/getinfo.py
@@ -88,13 +88,13 @@ def getInfoFromGFDLFilename(filename,dictInfo,logger):
 
     nlen = len(builderconfig.output_file_template) # ['modeling_realm','temporal_subset','variable_id']
     #lets go backwards and match given input directory to the template, add things to dictInfo
-    for i in range(1,nlen+1):
-      try:
-          dictInfo[builderconfig.output_file_template[nlen-i]] = ncfilename[-i]
-      except:
-          sys.exit("oops in getInfoFromGFDLFilename")
-    else:
-        logger.debug("Filename not compatible with this version of the builder:"+filename)
+    #for i in range(1,nlen+1):
+    #    try:
+    #        dictInfo[builderconfig.output_file_template[nlen-i]] = ncfilename[-i]
+    #  except:
+    #      sys.exit("oops in getInfoFromGFDLFilename")
+    #else:
+    #    logger.debug("Filename not compatible with this version of the builder:"+filename)
     return dictInfo
 
 def getInfoFromGFDLDRS(dirpath,projectdir,dictInfo):
@@ -133,7 +133,7 @@ def getInfoFromDRS(dirpath,projectdir,dictInfo):
     try:
         institute = stemdir[2]
     except:
-            institute = "NA"
+        institute = "NA"
     try:
         version = stemdir[9]
     except:

--- a/intakebuilder/gfdlcrawler.py
+++ b/intakebuilder/gfdlcrawler.py
@@ -31,19 +31,12 @@ def crawlLocal(projectdir, dictFilter,dictFilterIgnore,logger):
                dictInfo = {}
                dictInfo = getinfo.getProject(projectdir, dictInfo)
                # get info from filename
-               #print(filename)
                filepath = os.path.join(dirpath,filename)  # 1 AR: Bugfix: this needs to join dirpath and filename to get the full path to the file
                if not filename.endswith(".nc"):
                     logger.debug("FILE does not end with .nc. Skipping", filepath)
                     continue
                dictInfo["path"]=filepath
-               dictInfo = getinfo.getInfoFromGFDLFilename(filename, dictInfo,logger)
-               #print("from file name ", dictInfo)
-#              print("Calling getinfo.getInfoFromGFDLDRS(dirpath, projectdir, dictInfo)")
                dictInfo = getinfo.getInfoFromGFDLDRS(dirpath, projectdir, dictInfo)
-#              print("Calling getinfo.getInfoFromGlobalAtts(filepath, dictInfo)")
-#              dictInfo = getinfo.getInfoFromGlobalAtts(filepath, dictInfo)
-               #eliminate bad DRS filenames spotted
                list_bad_modellabel = ["","piControl","land-hist","piClim-SO2","abrupt-4xCO2","hist-piAer","hist-piNTCF","piClim-ghg","piClim-OC","hist-GHG","piClim-BC","1pctCO2"]
                list_bad_chunklabel = ['DO_NOT_USE']
                if "source_id" in dictInfo: 

--- a/intakebuilder/gfdlcrawler.py
+++ b/intakebuilder/gfdlcrawler.py
@@ -21,51 +21,49 @@ def crawlLocal(projectdir, dictFilter,dictFilterIgnore,logger):
     orig_pat = pat
     #TODO INCLUDE filter in traversing through directories at the top
     for dirpath, dirs, files in os.walk(projectdir):
-      if "atmos/ts/monthly/5yr" in dirpath: #TODO improved filtering
-            searchpath = dirpath
-            if (orig_pat is None):
-                pat = dirpath  #we assume matching entire path
-            if(pat is not None):
-                m = re.search(pat, searchpath)
-                for filename in files:
-                   logger.info(dirpath+"/"+filename)
-                   dictInfo = {}
-                   dictInfo = getinfo.getProject(projectdir, dictInfo)
-                   # get info from filename
-                   #print(filename)
-                   filepath = os.path.join(dirpath,filename)  # 1 AR: Bugfix: this needs to join dirpath and filename to get the full path to the file
-                   if not filename.endswith(".nc"):
-                        logger.debug("FILE does not end with .nc. Skipping", filepath)
-                        continue
-                   dictInfo["path"]=filepath
-                   #print("Calling getinfo.getInfoFromGFDLFilename(filename, dictInfo)..")
-                   dictInfo = getinfo.getInfoFromGFDLFilename(filename, dictInfo,logger)
-                   #print("from file name ", dictInfo)
-#                  print("Calling getinfo.getInfoFromGFDLDRS(dirpath, projectdir, dictInfo)")
-                   dictInfo = getinfo.getInfoFromGFDLDRS(dirpath, projectdir, dictInfo)
-#                  print("Calling getinfo.getInfoFromGlobalAtts(filepath, dictInfo)")
-#                  dictInfo = getinfo.getInfoFromGlobalAtts(filepath, dictInfo)
-                   #eliminate bad DRS filenames spotted
-                   list_bad_modellabel = ["","piControl","land-hist","piClim-SO2","abrupt-4xCO2","hist-piAer","hist-piNTCF","piClim-ghg","piClim-OC","hist-GHG","piClim-BC","1pctCO2"]
-                   list_bad_chunklabel = ['DO_NOT_USE']
-                   if "source_id" in dictInfo: 
-                     if(dictInfo["source_id"] in list_bad_modellabel):
-                        logger.debug("Found experiment name in model column, skipping this possibly bad DRS filename",filepath)
+        searchpath = dirpath
+        if (orig_pat is None):
+            pat = dirpath  #we assume matching entire path
+        if(pat is not None):
+            m = re.search(pat, searchpath)
+            for filename in files:
+               logger.info(dirpath+"/"+filename)
+               dictInfo = {}
+               dictInfo = getinfo.getProject(projectdir, dictInfo)
+               # get info from filename
+               #print(filename)
+               filepath = os.path.join(dirpath,filename)  # 1 AR: Bugfix: this needs to join dirpath and filename to get the full path to the file
+               if not filename.endswith(".nc"):
+                    logger.debug("FILE does not end with .nc. Skipping", filepath)
+                    continue
+               dictInfo["path"]=filepath
+               dictInfo = getinfo.getInfoFromGFDLFilename(filename, dictInfo,logger)
+               #print("from file name ", dictInfo)
+#              print("Calling getinfo.getInfoFromGFDLDRS(dirpath, projectdir, dictInfo)")
+               dictInfo = getinfo.getInfoFromGFDLDRS(dirpath, projectdir, dictInfo)
+#              print("Calling getinfo.getInfoFromGlobalAtts(filepath, dictInfo)")
+#              dictInfo = getinfo.getInfoFromGlobalAtts(filepath, dictInfo)
+               #eliminate bad DRS filenames spotted
+               list_bad_modellabel = ["","piControl","land-hist","piClim-SO2","abrupt-4xCO2","hist-piAer","hist-piNTCF","piClim-ghg","piClim-OC","hist-GHG","piClim-BC","1pctCO2"]
+               list_bad_chunklabel = ['DO_NOT_USE']
+               if "source_id" in dictInfo: 
+                   if(dictInfo["source_id"] in list_bad_modellabel):
+                       logger.debug("Found experiment name in model column, skipping this possibly bad DRS filename",filepath)
                    #   continue
-                   if "chunk_freq" in dictInfo:
-                     if(dictInfo["chunk_freq"] in list_bad_chunklabel):
-                        logger.debug("Found bad chunk, skipping this possibly bad DRS filename",filepath)
-                        continue     
+               if "chunk_freq" in dictInfo:
+                   if(dictInfo["chunk_freq"] in list_bad_chunklabel):
+                       logger.debug("Found bad chunk, skipping this possibly bad DRS filename",filepath)
+                       continue     
  
-                   # remove those keys that are not CSV headers 
-                   # move it so its one time 
-                   rmkeys = []
-                   for dkeys in dictInfo.keys():
-                      if dkeys not in builderconfig.headerlist:
-                          rmkeys.append(dkeys) 
-                   rmkeys = list(set(rmkeys))
+               # remove those keys that are not CSV headers 
+               # move it so its one time 
+               rmkeys = []
+               for dkeys in dictInfo.keys():
+                  if dkeys not in builderconfig.headerlist:
+                      rmkeys.append(dkeys) 
+               rmkeys = list(set(rmkeys))
 
-                   for k in rmkeys: dictInfo.pop(k,None)
+               for k in rmkeys: dictInfo.pop(k,None)
  
-                   listfiles.append(dictInfo)
+               listfiles.append(dictInfo)
     return listfiles


### PR DESCRIPTION
1. PPdir path expectations have been removed.

2. Experiment ID, frequency, member id, modeling realm, variable id, and chunk frequency are now properly grabbed from (only) time series output files.

3. Data lines with less than 3 values are no longer written to the CSV file. This is because 'activity id' and 'path' are automatically grabbed from all files. Only time series output files will have additional values associated with them.