### PR TITLE
Creating JSON and CSV file in output directory + Appending tweaks

### DIFF
--- a/.github/workflows/create-gfdl-catalog.yml
+++ b/.github/workflows/create-gfdl-catalog.yml
@@ -29,7 +29,7 @@ jobs:
       run: python tests/make_sample_data.py
     - name: 'Generate catalog'
       run: |
-        $CONDA/envs/catalogbuilder/bin/python gen_intake_gfdl.py archive/am5/am5/am5f3b1r0/c96L65_am5f3b1r0_pdclim1850F/gfdl.ncrc5-deploy-prod-openmp/pp cats/gfdl_autotest.csv
+        $CONDA/envs/catalogbuilder/bin/python gen_intake_gfdl.py archive/am5/am5/am5f3b1r0/c96L65_am5f3b1r0_pdclim1850F/gfdl.ncrc5-deploy-prod-openmp/pp cats/gfdl_autotest
     - name: Upload csv
       uses: actions/upload-artifact@v3
       with:

--- a/gen_intake_gfdl.py
+++ b/gen_intake_gfdl.py
@@ -48,14 +48,16 @@ def main(input_path,output_path,filter_realm,filter_freq,filter_chunk,overwrite,
     project_dir = project_dir.rstrip("/")
     logger.info("Calling gfdlcrawler.crawlLocal")
     list_files = gfdlcrawler.crawlLocal(project_dir, dictFilter, dictFilterIgnore,logger)
+
+    #Grabbing data from template JSON, changing CSV path to match output path, and dumping data in new JSON
     with open("cats/gfdl_test1.json", "r") as jsonTemplate:
         data = json.load(jsonTemplate)
         data["catalog_file"] = os.path.abspath(csv_path)
- 
     jsonFile = open(json_path, "w")
-    json.dump(data, jsonFile, indent=4)
+    json.dump(data, jsonFile, indent=2)
     jsonFile.close()
     headers = CSVwriter.getHeader()
+
     #When we pass relative path or just the filename the following still needs to not choke
     #so we check if it's a directory first
     if os.path.isdir(os.path.dirname(csv_path)):

--- a/gen_intake_gfdl.py
+++ b/gen_intake_gfdl.py
@@ -48,7 +48,7 @@ def main(input_path,output_path,filter_realm,filter_freq,filter_chunk,overwrite,
     project_dir = project_dir.rstrip("/")
     logger.info("Calling gfdlcrawler.crawlLocal")
     list_files = gfdlcrawler.crawlLocal(project_dir, dictFilter, dictFilterIgnore,logger)
-    with open("gfdl_test1.json", "r") as jsonTemplate:
+    with open("cats/gfdl_test1.json", "r") as jsonTemplate:
         data = json.load(jsonTemplate)
         data["catalog_file"] = os.path.abspath(csv_path)
  

--- a/gen_intake_gfdl.py
+++ b/gen_intake_gfdl.py
@@ -4,23 +4,25 @@ import json
 import click
 import os
 from intakebuilder import gfdlcrawler, CSVwriter, builderconfig
+from pathlib import Path
 import logging
 logger = logging.getLogger('local')
 logger.setLevel(logging.INFO)
 
 #Setting up argument parsing/flags
 @click.command()
-@click.argument("inputdir", required=True, nargs=1) 
-@click.argument("outputdir", required=True, nargs=1)
+@click.argument("input_path", required=True, nargs=1) 
+@click.argument("output_path", required=True, nargs=1)
 @click.option('--filter_realm', nargs=1)
 @click.option('--filter_freq', nargs=1)
 @click.option('--filter_chunk', nargs=1)
 @click.option('--overwrite', is_flag=True, default=False)
 @click.option('--append', is_flag=True, default=False) 
-def main(inputdir,outputdir,filter_realm,filter_freq,filter_chunk,overwrite,append):
-    project_dir = inputdir
-    csvfile = outputdir
-   
+def main(input_path,output_path,filter_realm,filter_freq,filter_chunk,overwrite,append):
+    project_dir = input_path
+    csv_path = output_path+".csv"
+    json_path = output_path+".json"
+ 
     ######### SEARCH FILTERS ###########################
     
     dictFilter = {}
@@ -46,20 +48,21 @@ def main(inputdir,outputdir,filter_realm,filter_freq,filter_chunk,overwrite,appe
     project_dir = project_dir.rstrip("/")
     logger.info("Calling gfdlcrawler.crawlLocal")
     list_files = gfdlcrawler.crawlLocal(project_dir, dictFilter, dictFilterIgnore,logger)
-    with open("gfdl_test1.json", "r") as jsonFile:
-        data = json.load(jsonFile)
-
-    data["catalog_file"] = os.path.abspath(outputdir)
-
-    with open("gfdl_test1.json", "w") as jsonFile:
-        json.dump(data, jsonFile, indent=4)
+    with open("gfdl_test1.json", "r") as jsonTemplate:
+        data = json.load(jsonTemplate)
+        data["catalog_file"] = os.path.abspath(csv_path)
+ 
+    jsonFile = open(json_path, "w")
+    json.dump(data, jsonFile, indent=4)
+    jsonFile.close()
     headers = CSVwriter.getHeader()
     #When we pass relative path or just the filename the following still needs to not choke
     #so we check if it's a directory first
-    if os.path.isdir(os.path.dirname(csvfile)):
-        os.makedirs(os.path.dirname(csvfile), exist_ok=True)
-    CSVwriter.listdict_to_csv(list_files, headers, csvfile, overwrite, append)
-    print("CSV generated at:", os.path.abspath(csvfile))
-    logger.info("CSV generated at"+ os.path.abspath(csvfile))
+    if os.path.isdir(os.path.dirname(csv_path)):
+        os.makedirs(os.path.dirname(csv_path), exist_ok=True)
+    CSVwriter.listdict_to_csv(list_files, headers, csv_path, overwrite, append)
+    print("JSON generated at:", os.path.abspath(json_path))
+    print("CSV generated at:", os.path.abspath(csv_path))
+    logger.info("CSV generated at"+ os.path.abspath(csv_path))
 if __name__ == '__main__':
     main()

--- a/gen_intake_gfdl.py
+++ b/gen_intake_gfdl.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import json
 import click
 import os
 from intakebuilder import gfdlcrawler, CSVwriter, builderconfig
@@ -45,6 +46,13 @@ def main(inputdir,outputdir,filter_realm,filter_freq,filter_chunk,overwrite,appe
     project_dir = project_dir.rstrip("/")
     logger.info("Calling gfdlcrawler.crawlLocal")
     list_files = gfdlcrawler.crawlLocal(project_dir, dictFilter, dictFilterIgnore,logger)
+    with open("gfdl_test1.json", "r") as jsonFile:
+        data = json.load(jsonFile)
+
+    data["catalog_file"] = os.path.abspath(outputdir)
+
+    with open("gfdl_test1.json", "w") as jsonFile:
+        json.dump(data, jsonFile, indent=4)
     headers = CSVwriter.getHeader()
     #When we pass relative path or just the filename the following still needs to not choke
     #so we check if it's a directory first

--- a/intakebuilder/CSVwriter.py
+++ b/intakebuilder/CSVwriter.py
@@ -55,8 +55,7 @@ def listdict_to_csv(dict_info,headerlist, csvfile, overwrite, append):
         if append:
             with open(csvfile, 'a') as csvfile:
                 writer = csv.DictWriter(csvfile, fieldnames=headerlist)
-                print("writing..")
-                writer.writeheader()
+                print("writing (without header)..")
                 for data in dict_info:
                     if len(data.keys()) > 2:
                         writer.writerow(data)
@@ -73,16 +72,17 @@ def listdict_to_csv(dict_info,headerlist, csvfile, overwrite, append):
                             print("writing..")
                             writer.writeheader()
                             for data in dict_info:
-                                writer.writerow(data)
+                                if len(data.keys()) > 2:
+                                    writer.writerow(data)
                         break
                     
                     elif user_input.lower() == 'n':
                         with open(csvfile, 'a') as csvfile:
                             writer = csv.DictWriter(csvfile, fieldnames=headerlist)
-                            print("appending to existing file...")
-                            writer.writeheader()
+                            print("appending (without header) to existing file...")
                             for data in dict_info:
-                                writer.writerow(data)
+                                if len(data.keys()) > 2:
+                                    writer.writerow(data)
                         break
                     #If the user types anything besides y/n, keep asking
                     else:
@@ -93,6 +93,7 @@ def listdict_to_csv(dict_info,headerlist, csvfile, overwrite, append):
                     print("writing..")
                     writer.writeheader()
                     for data in dict_info:
-                        writer.writerow(data)
+                        if len(data.keys()) > 2:
+                            writer.writerow(data)
     except IOError:
         print("I/O error")


### PR DESCRIPTION
This update now creates a JSON + compatible CSV file in the specified output location. The user must now call the catalog builder using "/output_dir/file_name" (without file ending) as the output path. 

This update also fixes a print bug when appending to an existing catalog.